### PR TITLE
Swo 99 error handler middleware should able to determine retry

### DIFF
--- a/src/utils/custom-error/index.test.ts
+++ b/src/utils/custom-error/index.test.ts
@@ -9,6 +9,7 @@ describe('CustomError', () => {
     expect(error.name).toBe('CustomError');
     expect(error.errorCode).toBe('UNKNOWN_ERROR');
     expect(error.severity).toBe('medium');
+    expect(error.shouldRetry).toBe(false);
     expect(error.contexts).toHaveLength(1);
     expect(error.contexts[0].source).toBe('Unknown');
     expect(error.timestamp).toBeDefined();
@@ -26,11 +27,13 @@ describe('CustomError', () => {
       context,
       source: 'UserService',
       originalError,
+      shouldRetry: true,
     });
 
     expect(error.message).toBe('Specific error');
     expect(error.errorCode).toBe('USER_ERROR');
     expect(error.severity).toBe('high');
+    expect(error.shouldRetry).toBe(true);
     expect(error.contexts).toHaveLength(2);
     expect(error.contexts[0].source).toBe('UserService');
     expect(error.contexts[0].data).toEqual({ userId: 123 });

--- a/src/utils/custom-error/index.test.ts
+++ b/src/utils/custom-error/index.test.ts
@@ -192,5 +192,13 @@ describe('CustomError', () => {
         expect(error.originalError).toBeInstanceOf(Error);
       }
     });
+
+    it('should preserve shouldRetry through error propagation', () => {
+      const lowLevelError = new CustomError('Low level error', { shouldRetry: true });
+      const midLevelError = new CustomError('Mid level error', { originalError: lowLevelError });
+      const highLevelError = new CustomError('High level error', { originalError: midLevelError });
+
+      expect(highLevelError.shouldRetry).toBe(true);
+    });
   });
 });

--- a/src/utils/custom-error/index.ts
+++ b/src/utils/custom-error/index.ts
@@ -116,6 +116,10 @@ class CustomError extends Error {
       if (originalError.stack) {
         this.stack = originalError.stack;
       }
+
+      if (originalError.shouldRetry) {
+        this.shouldRetry = originalError.shouldRetry;
+      }
     }
     // If wrapping a regular Error
     else if (originalError instanceof Error) {

--- a/src/utils/custom-error/index.ts
+++ b/src/utils/custom-error/index.ts
@@ -21,6 +21,7 @@ interface ErrorOptions {
   context?: Record<string, unknown>;
   source?: string;
   originalError?: Error | CustomError;
+  shouldRetry?: boolean;
 }
 
 /**
@@ -60,6 +61,12 @@ class CustomError extends Error {
   public readonly severity: ErrorSeverity;
 
   /**
+   * Severity level of the error.
+   * @type {boolean}
+   */
+  public readonly shouldRetry: boolean;
+
+  /**
    * Array of error contexts providing additional information about the error.
    * @type {ErrorContext[]}
    */
@@ -85,12 +92,14 @@ class CustomError extends Error {
       context = {},
       source = 'Unknown',
       originalError,
+      shouldRetry = false,
     } = options;
 
     this.name = 'CustomError';
     this.timestamp = Date.now();
     this.errorCode = errorCode;
     this.severity = severity;
+    this.shouldRetry = shouldRetry;
     this.contexts = [];
 
     // If wrapping a CustomError

--- a/src/utils/custom-error/index.ts
+++ b/src/utils/custom-error/index.ts
@@ -61,7 +61,7 @@ class CustomError extends Error {
   public readonly severity: ErrorSeverity;
 
   /**
-   * Severity level of the error.
+   * Determine the ability to retry the request or not
    * @type {boolean}
    */
   public readonly shouldRetry: boolean;

--- a/src/utils/error-handler.test.ts
+++ b/src/utils/error-handler.test.ts
@@ -98,7 +98,7 @@ describe('errorHandler', () => {
     expect(mockResponse.status).toHaveBeenCalledWith(200);
     // Check response
     expect(mockResponse.json).toHaveBeenCalledWith({
-      error: 'Custom test error',
+      error: 'Internal Server Error',
     });
   });
 
@@ -123,27 +123,6 @@ describe('errorHandler', () => {
 
     expect(mockResponse.status).toHaveBeenCalledWith(200);
     // Check response
-    expect(mockResponse.json).toHaveBeenCalledWith({
-      error: 'Test error',
-    });
-  });
-
-  it('should handle errors in production mode', () => {
-    process.env.NODE_ENV = 'production';
-    const error = new Error('Test error');
-    const handler = errorHandler(mockLogger);
-
-    handler(error, mockRequest, mockResponse, vi.fn());
-
-    expect(mockLogger.error).toHaveBeenCalledWith({
-      req: {
-        method: 'POST',
-        url: '/webhook',
-      },
-      stack: expect.not.stringContaining('node_modules'),
-    });
-
-    expect(mockResponse.status).toHaveBeenCalledWith(200);
     expect(mockResponse.json).toHaveBeenCalledWith({
       error: 'Internal Server Error',
     });
@@ -170,5 +149,45 @@ describe('errorHandler', () => {
         stack: expect.not.stringContaining('node_modules'),
       })
     );
+  });
+
+  it('should return 500 status code for errors marked as retriable', () => {
+    const retriableError = new CustomError('Retriable error', {
+      shouldRetry: true,
+    });
+
+    const handler = errorHandler(mockLogger);
+    handler(retriableError, mockRequest, mockResponse, vi.fn());
+
+    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      error: 'Internal Server Error',
+    });
+  });
+
+  it('should return 200 status code for errors not marked as retriable', () => {
+    const nonRetriableError = new CustomError('Non-retriable error', {
+      shouldRetry: false,
+    });
+
+    const handler = errorHandler(mockLogger);
+    handler(nonRetriableError, mockRequest, mockResponse, vi.fn());
+
+    expect(mockResponse.status).toHaveBeenCalledWith(200);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      error: 'Internal Server Error',
+    });
+  });
+
+  it('should return 200 status code by default', () => {
+    const nonRetriableError = new Error('Any error');
+
+    const handler = errorHandler(mockLogger);
+    handler(nonRetriableError, mockRequest, mockResponse, vi.fn());
+
+    expect(mockResponse.status).toHaveBeenCalledWith(200);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      error: 'Internal Server Error',
+    });
   });
 });

--- a/src/utils/error-handler.test.ts
+++ b/src/utils/error-handler.test.ts
@@ -140,7 +140,7 @@ describe('errorHandler', () => {
         method: 'POST',
         url: '/webhook',
       },
-      stack: undefined,
+      stack: expect.not.stringContaining('node_modules'),
     });
 
     expect(mockResponse.status).toHaveBeenCalledWith(200);

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -12,7 +12,7 @@ const cleanStack = (stack?: string) => {
     .join('\n');
 };
 
-const handleError = (err: unknown) => {
+const reportError = (err: unknown) => {
   if (err instanceof CustomError) {
     Sentry.withScope(scope => {
       scope.setTags({
@@ -51,20 +51,17 @@ const handleError = (err: unknown) => {
 export const errorHandler = (logger: Logger): ErrorRequestHandler => {
   // next is required for nextjs
   return (err, req, res, next) => {
-    handleError(err);
+    reportError(err);
 
     logger.error({
       req: {
         method: req.method,
         url: req.url,
       },
-      // Include stack in non-production
       stack: cleanStack(err.stack),
     });
     const statusCode = err instanceof CustomError && err.shouldRetry ? 500 : 200;
 
-    // TODO
-    // Handle retry from error
     return res.status(statusCode).json({
       error: 'Internal Server Error',
     });

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -3,53 +3,57 @@ import { ErrorRequestHandler } from 'express';
 import { Logger } from 'pino';
 import { CustomError } from './custom-error';
 
+const cleanStack = (stack?: string) => {
+  if (!stack) return undefined;
+
+  return stack
+    .split('\n')
+    .filter(line => !line.includes('node_modules'))
+    .join('\n');
+};
+
+const handleError = (err: unknown) => {
+  if (err instanceof CustomError) {
+    Sentry.withScope(scope => {
+      scope.setTags({
+        errorCode: err.errorCode,
+        severity: err.severity,
+      });
+
+      // Add error context as extra data
+      if (err.contexts?.length > 0) {
+        err.contexts.forEach(context => {
+          scope.setExtra(context.source, context.data);
+        });
+      }
+
+      // Add original error if exists
+      if (err.originalError) {
+        scope.setExtra('originalError', {
+          message: err.originalError.message,
+          name: err.originalError.name,
+          stack: err.originalError.stack,
+        });
+      }
+
+      Sentry.captureException(err);
+    });
+  } else {
+    // For native errors, just capture with basic info
+    Sentry.withScope(scope => {
+      scope.setLevel('error');
+      scope.setTag('type', 'native_error');
+      Sentry.captureException(err);
+    });
+  }
+};
+
 export const errorHandler = (logger: Logger): ErrorRequestHandler => {
   const isProduction = process.env.NODE_ENV === 'production';
 
-  const cleanStack = (stack?: string) => {
-    if (!stack) return undefined;
-
-    return stack
-      .split('\n')
-      .filter(line => !line.includes('node_modules'))
-      .join('\n');
-  };
-
   // next is required for nextjs
   return (err, req, res, next) => {
-    if (err instanceof CustomError) {
-      Sentry.withScope(scope => {
-        scope.setTags({
-          errorCode: err.errorCode,
-          severity: err.severity,
-        });
-
-        // Add error context as extra data
-        if (err.contexts?.length > 0) {
-          err.contexts.forEach(context => {
-            scope.setExtra(context.source, context.data);
-          });
-        }
-
-        // Add original error if exists
-        if (err.originalError) {
-          scope.setExtra('originalError', {
-            message: err.originalError.message,
-            name: err.originalError.name,
-            stack: err.originalError.stack,
-          });
-        }
-
-        Sentry.captureException(err);
-      });
-    } else {
-      // For native errors, just capture with basic info
-      Sentry.withScope(scope => {
-        scope.setLevel('error');
-        scope.setTag('type', 'native_error');
-        Sentry.captureException(err);
-      });
-    }
+    handleError(err);
 
     logger.error({
       req: {
@@ -57,7 +61,7 @@ export const errorHandler = (logger: Logger): ErrorRequestHandler => {
         url: req.url,
       },
       // Include stack in non-production
-      stack: isProduction ? undefined : cleanStack(err.stack),
+      stack: cleanStack(err.stack),
     });
 
     // TODO

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -49,8 +49,6 @@ const handleError = (err: unknown) => {
 };
 
 export const errorHandler = (logger: Logger): ErrorRequestHandler => {
-  const isProduction = process.env.NODE_ENV === 'production';
-
   // next is required for nextjs
   return (err, req, res, next) => {
     handleError(err);
@@ -63,11 +61,12 @@ export const errorHandler = (logger: Logger): ErrorRequestHandler => {
       // Include stack in non-production
       stack: cleanStack(err.stack),
     });
+    const statusCode = err instanceof CustomError && err.shouldRetry ? 500 : 200;
 
     // TODO
     // Handle retry from error
-    return res.status(200).json({
-      error: isProduction ? 'Internal Server Error' : err.message,
+    return res.status(statusCode).json({
+      error: 'Internal Server Error',
     });
   };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new optional `shouldRetry` property in error handling, allowing specification of whether an error should be retried.
  - Enhanced error handling now delivers a consistent, generic error message in production.
  - Errors are processed with improved logic that distinguishes between retryable and non-retryable outcomes, ensuring a more predictable response behavior.
  
- **Bug Fixes**
  - Adjusted error response status codes based on the `shouldRetry` property, ensuring accurate HTTP status codes are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->