### PR TITLE
Swo 136 bug report hls process segment name

### DIFF
--- a/src/apps/io/videos/index.ts
+++ b/src/apps/io/videos/index.ts
@@ -1,13 +1,13 @@
 import express, { Router } from 'express';
-import { streamHLSHandler } from './routes/stream-hls';
-import { importPlatformHandler } from './routes/import-platform';
 import { validateRequest } from 'src/utils/validator';
-import { StreamHandlerRequest, StreamHandlerSchema } from './routes/stream-hls/schema';
-import { ImportHandlerRequest, ImportHandlerSchema } from './routes/import-platform/schema';
-import { FixDurationHandlerRequest, FixDurationHandlerSchema } from './routes/fix-duration/schema';
 import { fixDurationHandler } from './routes/fix-duration';
+import { FixDurationHandlerRequest, FixDurationHandlerSchema } from './routes/fix-duration/schema';
 import { fixThumbnailHandler } from './routes/fix-thumbnail';
 import { FixThumbnailHandlerRequest, FixThumbnailHandlerSchema } from './routes/fix-thumbnail/schema';
+import { importPlatformHandler } from './routes/import-platform';
+import { ImportHandlerRequest, ImportHandlerSchema } from './routes/import-platform/schema';
+import { streamHLSHandler } from './routes/stream-hls';
+import { StreamHandlerRequest, StreamHandlerSchema } from './routes/stream-hls/schema';
 
 const videosRouter: Router = express.Router();
 

--- a/src/services/videos/helpers/m3u8/index.test.ts
+++ b/src/services/videos/helpers/m3u8/index.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { streamM3U8 } from './index';
-import { parseM3U8Content, streamPlaylistFile, streamSegments } from './helpers';
-import { getDownloadUrl } from '../gcp-cloud-storage';
-import { logger } from 'src/utils/logger';
 import { CustomError } from 'src/utils/custom-error';
 import { VIDEO_ERRORS } from 'src/utils/error-codes';
+import { logger } from 'src/utils/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDownloadUrl } from '../gcp-cloud-storage';
 import { processThumbnail } from '../thumbnail';
+import { parseM3U8Content, streamPlaylistFile, streamSegments } from './helpers';
+import { streamM3U8 } from './index';
 
 // Mock dependencies
 vi.mock('./helpers');
@@ -42,10 +42,10 @@ describe('streamM3U8', () => {
     thumbnailUrl: mockThumbnailUrl,
     segments: {
       included: [
-        { url: 'segment1.ts', duration: 3 },
-        { url: 'segment2.ts', duration: 3 },
+        { url: 'segment1.ts', name: '0.ts', duration: 3 },
+        { url: 'segment2.ts', name: '1.ts', duration: 3 },
       ],
-      excluded: [{ url: 'segment3.ts' }],
+      excluded: [{ url: 'segment3.ts', name: '' }],
     },
     duration: 300,
   };
@@ -79,7 +79,7 @@ describe('streamM3U8', () => {
     expect(parseM3U8Content).toHaveBeenCalledWith(mockM3u8Url, undefined);
     expect(streamPlaylistFile).toHaveBeenCalledWith('#EXTM3U\n#EXT-X-VERSION:3', 'videos/test-video/playlist.m3u8');
     expect(streamSegments).toHaveBeenCalledWith({
-      segmentUrls: ['segment1.ts', 'segment2.ts'],
+      segments: expectedResult.segments.included,
       baseStoragePath: mockStoragePath,
       options: {},
     });
@@ -101,7 +101,7 @@ describe('streamM3U8', () => {
     await streamM3U8(mockM3u8Url, mockStoragePath, options);
 
     expect(streamSegments).toHaveBeenCalledWith({
-      segmentUrls: ['segment1.ts', 'segment2.ts'],
+      segments: expectedResult.segments.included,
       baseStoragePath: mockStoragePath,
       options,
     });

--- a/src/services/videos/helpers/m3u8/index.ts
+++ b/src/services/videos/helpers/m3u8/index.ts
@@ -1,10 +1,10 @@
 import path from 'path';
-import { getDownloadUrl } from '../gcp-cloud-storage';
-import { logger } from 'src/utils/logger';
-import { parseM3U8Content, streamPlaylistFile, streamSegments } from './helpers';
 import { CustomError } from 'src/utils/custom-error';
 import { VIDEO_ERRORS } from 'src/utils/error-codes';
+import { logger } from 'src/utils/logger';
+import { getDownloadUrl } from '../gcp-cloud-storage';
 import { processThumbnail } from '../thumbnail';
+import { parseM3U8Content, streamPlaylistFile, streamSegments } from './helpers';
 
 interface ProcessOptions {
   excludePatterns?: RegExp[];
@@ -95,7 +95,7 @@ const streamM3U8 = async (m3u8Url: string, storagePath: string, options: Process
 
     // Stream segments in parallel
     await streamSegments({
-      segmentUrls: segments.included.map(s => s.url),
+      segments: segments.included,
       baseStoragePath: storagePath,
       options,
     });
@@ -120,4 +120,4 @@ const streamM3U8 = async (m3u8Url: string, storagePath: string, options: Process
   }
 };
 
-export { streamM3U8, ProcessOptions };
+export { ProcessOptions, streamM3U8 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standardized segment naming for video streaming, assigning sequential names (e.g., "0.ts", "1.ts") to video segments.
- **Bug Fixes**
  - Improved error handling for empty segment responses during video streaming.
- **Tests**
  - Updated test cases to reflect new segment naming conventions and input formats.
- **Refactor**
  - Streamlined segment handling by passing objects with both name and URL, enhancing code clarity and maintainability.
- **Style**
  - Reordered import and export statements for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->