### PR TITLE
Swo 140 allow keep original source feature

### DIFF
--- a/src/apps/io/videos/routes/stream-hls/index.test.ts
+++ b/src/apps/io/videos/routes/stream-hls/index.test.ts
@@ -257,4 +257,38 @@ describe('streamHLSHandler', () => {
       }
     );
   });
+
+  it('should skip HLS conversion when keepOriginalSource is true', async () => {
+    const customData = {
+      ...context.defaultData,
+      keepOriginalSource: true,
+    };
+    const customRequest = createMockRequest(customData, context.defaultMetadata, context.defaultTaskId);
+
+    await streamHLSHandler(customRequest, context.mockResponse);
+
+    // Should not call streamM3U8
+    expect(streamM3U8).not.toHaveBeenCalled();
+
+    // Should call finishVideoProcess with original URL
+    expect(finishVideoProcess).toHaveBeenCalledWith({
+      taskId: context.defaultTaskId,
+      notificationObject: {
+        type: 'video-ready',
+        entityId: context.defaultData.id,
+        entityType: 'video',
+        user_id: context.defaultData.userId,
+      },
+      videoId: context.defaultData.id,
+      videoUpdates: {
+        source: context.defaultData.videoUrl,
+        status: 'ready',
+      },
+    });
+
+    // Should return original URL as playable URL
+    expect(context.mockResponse.json).toHaveBeenCalledWith({
+      playableVideoUrl: context.defaultData.videoUrl,
+    });
+  });
 });

--- a/src/apps/io/videos/routes/stream-hls/index.test.ts
+++ b/src/apps/io/videos/routes/stream-hls/index.test.ts
@@ -291,4 +291,48 @@ describe('streamHLSHandler', () => {
       playableVideoUrl: context.defaultData.videoUrl,
     });
   });
+
+  it('should handle Hasura error when keepOriginalSource is true', async () => {
+    const customData = {
+      ...context.defaultData,
+      keepOriginalSource: true,
+    };
+    const customRequest = createMockRequest(customData, context.defaultMetadata, context.defaultTaskId);
+    context.mockRequest = customRequest; // Important: Update the context request
+
+    // Setup Hasura failure BEFORE testErrorScenario
+    const hasuraError = CustomError.critical('Hasura mutation failed', {
+      errorCode: HTTP_ERRORS.SERVER_ERROR,
+      shouldRetry: true,
+    });
+    vi.mocked(finishVideoProcess).mockRejectedValueOnce(hasuraError);
+
+    await testErrorScenario(
+      () => {
+        // Empty setup since mocks are already configured
+      },
+      HTTP_ERRORS.SERVER_ERROR,
+      'Hasura server error',
+      () => {
+        expect(streamM3U8).not.toHaveBeenCalled();
+        expect(context.mockResponse.json).not.toHaveBeenCalled();
+
+        // Verify finishVideoProcess was called with expected arguments
+        expect(finishVideoProcess).toHaveBeenCalledWith({
+          taskId: context.defaultTaskId,
+          notificationObject: {
+            type: 'video-ready',
+            entityId: context.defaultData.id,
+            entityType: 'video',
+            user_id: context.defaultData.userId,
+          },
+          videoId: context.defaultData.id,
+          videoUpdates: {
+            source: context.defaultData.videoUrl,
+            status: 'ready',
+          },
+        });
+      }
+    );
+  });
 });

--- a/src/apps/io/videos/routes/stream-hls/index.ts
+++ b/src/apps/io/videos/routes/stream-hls/index.ts
@@ -9,7 +9,26 @@ import { logger } from 'src/utils/logger';
 const streamHLSHandler = async (req: Request, res: Response) => {
   const { data, metadata } = req.body;
   const taskId = req.headers['x-task-id'] as string;
-  const { id, videoUrl, userId } = data;
+  const { id, videoUrl, userId, keepOriginalSource } = data;
+
+  if (keepOriginalSource) {
+    await finishVideoProcess({
+      taskId,
+      notificationObject: {
+        type: 'video-ready',
+        entityId: id,
+        entityType: 'video',
+        user_id: userId,
+      },
+      videoId: id,
+      videoUpdates: {
+        source: videoUrl,
+        status: 'ready',
+      },
+    });
+
+    return res.json({ playableVideoUrl: videoUrl });
+  }
 
   logger.info(metadata, `[/videos/stream-hls-handler] start processing event "${metadata.id}", video "${id}"`);
   const {

--- a/src/apps/io/videos/routes/stream-hls/schema.test.ts
+++ b/src/apps/io/videos/routes/stream-hls/schema.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { StreamHandlerSchema } from './schema';
 
 describe('StreamHandlerSchema', () => {
@@ -18,6 +18,7 @@ describe('StreamHandlerSchema', () => {
     id: '123e4567-e89b-12d3-a456-426614174000',
     userId: '123e4567-e89b-12d3-a456-426614174001',
     videoUrl: 'https://storage.example.com/video.mp4',
+    keepOriginalSource: false,
   };
 
   // Helper function to create test request

--- a/src/apps/io/videos/routes/stream-hls/schema.ts
+++ b/src/apps/io/videos/routes/stream-hls/schema.ts
@@ -1,6 +1,6 @@
-import { z } from 'zod';
 import { EventMetadataSchema, VideoDataSchema } from 'src/services/videos/convert/schema';
 import { taskHandlerHeaderSchema } from 'src/utils/cloud-task/schema';
+import { z } from 'zod';
 
 const StreamHandlerSchema = z.object({
   body: z.object({
@@ -8,6 +8,7 @@ const StreamHandlerSchema = z.object({
       id: VideoDataSchema.shape.id,
       userId: VideoDataSchema.shape.user_id,
       videoUrl: VideoDataSchema.shape.video_url,
+      keepOriginalSource: VideoDataSchema.shape.keep_original_source,
     }),
     metadata: z.object({
       id: EventMetadataSchema.shape.id,

--- a/src/services/videos/convert/schema.test.ts
+++ b/src/services/videos/convert/schema.test.ts
@@ -15,6 +15,7 @@ describe('ConvertSchema', () => {
           user_id: '550e8400-e29b-41d4-a716-446655440001',
           video_url: 'https://example.com/video.mp4',
           skip_process: false,
+          keep_original_source: false,
         },
       },
     },
@@ -121,6 +122,7 @@ describe('ConvertSchema', () => {
             videoUrl: 'https://example.com/video.mp4',
             fileType: 'video',
             skipProcess: false,
+            keepOriginalSource: false,
             platform: null,
           },
           metadata: {

--- a/src/services/videos/convert/schema.ts
+++ b/src/services/videos/convert/schema.ts
@@ -20,6 +20,7 @@ const VideoDataSchema = z.object({
   user_id: z.string().uuid(),
   video_url: videoUrlSchema,
   skip_process: z.boolean(),
+  keep_original_source: z.boolean(),
 });
 
 const EventMetadataSchema = z.object({
@@ -43,6 +44,7 @@ const transformEvent = (event: z.infer<typeof EventSchema>) => {
       userId: event.data.user_id,
       videoUrl: event.data.video_url,
       skipProcess: event.data.skip_process,
+      keepOriginalSource: event.data.keep_original_source,
       platform,
       fileType,
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an option to keep the original video source without HLS conversion, allowing videos to be processed and accessed in their original format.
- **Bug Fixes**
  - Improved validation and schema handling to support the new option.
- **Tests**
  - Enhanced test coverage to verify correct behavior and error handling when the new option is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->